### PR TITLE
fix: update README to use the correct pokemon-showdown repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ uv run python scripts/evaluation/evaluate_gen9ou.py
 2. Set up the battle server:
 
 ```sh
-git clone git@github.com:jakegrigsby/pokemon-showdown.git
+git clone https://github.com/smogon/pokemon-showdown.git
 cd pokemon-showdown
 npm install
 cp config/config-example.js config/config.js


### PR DESCRIPTION
While setting up the environment, I noticed that the repository referenced in the README no longer exists. It appears to have been moved to the current repository. I updated the link accordingly and verified that the setup works without issues.

I also switched the instructions from ssh-based cloning to HTTP-based cloning, as HTTP is more widely supported.